### PR TITLE
Added static dns entries format for RouterOS

### DIFF
--- a/export-configure.py
+++ b/export-configure.py
@@ -17,6 +17,7 @@ formats = {
     'hosts': '{ip:<15} {domain}',
     'surge': '{domain} = {ip}',
     'merlin': 'address=/{domain}/{ip}',
+    'ros': 'add name {domain} address={ip}'
 }
 
 


### PR DESCRIPTION
增加了RouterOS下 ip -> dns -> static 条目的命令行导入语句。

方法是ssh到RouterOS，然后输入`ip dns static`进入静态dns条目配置界面，把生成的条目粘帖并回车即可。

如果要重新生成，需要手动进入routeros的配置界面删除相关条目以后再重新生成